### PR TITLE
Feat: allow cors

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
 from flask import Flask, request, jsonify, make_response
+from flask_cors import CORS
 import json
 
 from src import greedy
 
 app = Flask(__name__)
 
+cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
 
 @app.route("/gomoku/cpu", methods=['GET'])
 def get_gomoku():

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from src import greedy
 
 app = Flask(__name__)
 
-cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
+cors = CORS(app, resources={"*": {"origins": "*"}})
 
 @app.route("/gomoku/cpu", methods=['GET'])
 def get_gomoku():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask~=2.0.1
+Flask_Cors~=3.0.10


### PR DESCRIPTION
## Why
```sh
localhost:5000/~~~  from origin 'http://localhost:3001' has been blocked by CORS policy: 
No 'Access-Control-Allow-Origin' header is present on the requested resource. 
If an opaque response serves your needs, 
set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```
上記のエラーの通り、CORS制限がデフォルトで入っているため、フロントアプリからHttpリクエストが飛ばせなかった。
## What
- `flask-cors`をインストール
- 全リクエストを許可するようにCORSを設定